### PR TITLE
Update hadoop-meta/pom.xml build option to fixe compilation failure

### DIFF
--- a/hadoop-meta/pom.xml
+++ b/hadoop-meta/pom.xml
@@ -12,12 +12,15 @@
   <packaging>pom</packaging>
   <version>4.0</version>
   <name>Hadoop dependencies</name>
-
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This commit fixes the following error
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project common: Compilation failure: Compilation failure: 
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
```