### PR TITLE
Suggest to compile regex Pattern once

### DIFF
--- a/ch02-mr-intro/src/main/java/MaxTemperatureMapper.java
+++ b/ch02-mr-intro/src/main/java/MaxTemperatureMapper.java
@@ -11,7 +11,7 @@ public class MaxTemperatureMapper
   extends Mapper<LongWritable, Text, Text, IntWritable> {
 
   private static final int MISSING = 9999;
-  private static final Pattern qualityPattern = Pattern.compile("[01459]");
+  private static final Pattern QUALITY_PATTERN = Pattern.compile("[01459]");
   
   @Override
   public void map(LongWritable key, Text value, Context context)
@@ -25,8 +25,7 @@ public class MaxTemperatureMapper
     } else {
       airTemperature = Integer.parseInt(line.substring(87, 92));
     }
-    String quality = line.substring(92, 93);
-    if (airTemperature != MISSING && qualityPattern.matcher(quality).matches()) {
+    if (airTemperature != MISSING && QUALITY_PATTERN.matcher(line.substring(92, 93)).matches()) {
       context.write(new Text(year), new IntWritable(airTemperature));
     }
   }

--- a/ch02-mr-intro/src/main/java/MaxTemperatureMapper.java
+++ b/ch02-mr-intro/src/main/java/MaxTemperatureMapper.java
@@ -11,6 +11,7 @@ public class MaxTemperatureMapper
   extends Mapper<LongWritable, Text, Text, IntWritable> {
 
   private static final int MISSING = 9999;
+  private static final Pattern qualityPattern = Pattern.compile("[01459]");
   
   @Override
   public void map(LongWritable key, Text value, Context context)
@@ -25,7 +26,7 @@ public class MaxTemperatureMapper
       airTemperature = Integer.parseInt(line.substring(87, 92));
     }
     String quality = line.substring(92, 93);
-    if (airTemperature != MISSING && quality.matches("[01459]")) {
+    if (airTemperature != MISSING && qualityPattern.matcher(quality).matches()) {
       context.write(new Text(year), new IntWritable(airTemperature));
     }
   }


### PR DESCRIPTION
http://www.javapractices.com/topic/TopicAction.do?Id=104

I know that this is definitely not the main concern of this example, but I just want to address it.
Because many people would see the example without noticing the performance problem of java regex Pattern compilation.